### PR TITLE
Add code owners config and update CI workflow for Pulumi dependency

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# The owners will be put automatically as reviewer for any pr opened on this repo
+
+## <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners>
+
+@mountainash
+/infrastructure @mountainash
+/.github/workflows @mountainash

--- a/.github/workflows/pages-deployment.yaml
+++ b/.github/workflows/pages-deployment.yaml
@@ -1,10 +1,19 @@
 name: Website Deploy ⚡
 
 on:
-  push:
-    branches:
-      - prod
-      - preprod
+  # Allows triggering from another Workflow
+  workflow_call:
+    inputs:
+      CLOUDFLARE_ACCOUNT_ID:
+        type: string
+        required: true
+    secrets:
+      CLOUDFLARE_API_TOKEN:
+        required: true
+      SHARED_GITHUB_TOKEN:
+        required: true
+
+  # Allows triggering manually from the GitHub Actions tab
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pulumi.yaml
+++ b/.github/workflows/pulumi.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - prod
-      - preprod
+      - develop
   workflow_dispatch:
 
 env:
@@ -15,6 +15,11 @@ env:
   PULUMI_WORKING_DIRECTORY: ./infrastructure/
   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
   CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+
+# Prevent concurrent releases
+concurrency:
+  group: websitedeployment-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   pulumi:
@@ -29,9 +34,9 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: ${{ env.PULUMI_WORKING_DIRECTORY }}/package.json
           cache: yarn
-          cache-dependency-path: yarn.lock
+          cache-dependency-path: ${{ env.PULUMI_WORKING_DIRECTORY }}/yarn.lock
 
       - name: Install Dependencies 📦
         run: yarn install --immutable
@@ -52,3 +57,13 @@ jobs:
           command: up
           stack-name: ${{ env.PULUMI_STACK_NAME }}
           work-dir: ${{ env.PULUMI_WORKING_DIRECTORY }}
+
+  call-deployment-workflow:
+    name: Deploy website - Cloudflare Pages ⚡
+    needs: pulumi
+    uses: ./.github/workflows/pages-deployment.yaml
+    with:
+      CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      SHARED_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a code owners configuration to automatically assign reviewers for pull requests. Additionally, it modifies the CI workflow to ensure that the Pulumi deployment is completed before triggering the Cloudflare Pages deployment. The workflow now runs on the `develop` branch instead of `preprod`, and the Node version is sourced from `package.json`.

Fixes #67